### PR TITLE
Alooma: remove app extension macro around flush call.

### DIFF
--- a/Alooma-iOS/Alooma.m
+++ b/Alooma-iOS/Alooma.m
@@ -366,9 +366,10 @@ static __unused NSString *MPURLEncode(NSString *s)
             [self archiveEvents];
         }
     });
-#if defined(ALOOMA_APP_EXTENSION)
+
+  if (!self.application) {
     [self flush];
-#endif
+  }
 }
 
 


### PR DESCRIPTION
@StatusReport This is one place that I forgot it in (it resulted in Alooma not flushing events when `self.application` was `nil`).
Did an E-E test with `application` set to an actual `+[UIApplication sharedApplication]` and `nil`.